### PR TITLE
fix: highlighting for `auto_highlight = "all"`

### DIFF
--- a/lua/rocks_treesitter/highlight.lua
+++ b/lua/rocks_treesitter/highlight.lua
@@ -121,7 +121,7 @@ function highlight.create_autocmd()
             local bufnr = ctx.buf
             local filetype = vim.bo[bufnr].filetype
             local lang = get_lang(filetype)
-            if config.auto_highlight[lang] then
+            if config.auto_highlight == "all" or config.auto_highlight[lang] then
                 do_highlight(lang)
             end
         end,


### PR DESCRIPTION
I noticed that things didn't seem to work if I had `auto_highlight = "all"`, and I think this should fix it. Haven't actually tested it though as you can't point to a local path for a plugin yet (eagerly awaiting https://github.com/nvim-neorocks/rocks.nvim/issues/94).