### PR TITLE
fix(config): handle when `auto_install` is set to `false`

### DIFF
--- a/lua/rocks_treesitter/config.lua
+++ b/lua/rocks_treesitter/config.lua
@@ -39,7 +39,7 @@ config.auto_highlight = opts.auto_highlight == "all" and "all"
         acc[lang] = true
         return acc
     end)
-config.auto_install = opts.auto_install ~= nil and opts.auto_install or config.auto_install
+config.auto_install = vim.F.if_nil(opts.auto_install, config.auto_install)
 config.parser_map = vim.tbl_extend("force", config.parser_map, opts.parser_map or {})
 
 return config


### PR DESCRIPTION
minor fix for when `auto_install` is set to `false`

https://github.com/nvim-neorocks/rocks-treesitter.nvim/blob/34b33694a5b8f47aded92947ba8bbcce9a4e3b7e/lua/rocks_treesitter/config.lua#L42

When `opts.auto_install` is set to `false`, `config.auto_install` becomes `”prompt”` because of how lua ternary works.[^1]
`true and false or “prompt”` in lua is `”prompt”`

[^1]: https://lua-users.org/wiki/TernaryOperator