### PR TITLE
feat: Add support for an optional import config path

### DIFF
--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -27,4 +27,4 @@ jobs:
         with:
           version: ${{ env.LUAROCKS_VERSION }}
           dependencies: |
-            rocks.nvim >= 1.19.0
+            rocks.nvim >= 2.42.0

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ auto_install = "prompt" # true | false
 disable = [
   "lhaskell"
 ]
+config_path = "rocks-treesitter.toml"
 
 [treesitter.parser_map]
 # You can add custom filetype to parser mappings.
@@ -118,6 +119,7 @@ vim.g.rocks_nvim = {
         parser_map = { },
         ---@type string[] | fun(lang: string, bufnr: integer):boolean
         disable = { }, -- filetypes or a function
+        config_path = "rocks-treesitter.toml",
     },
 }
 ```

--- a/doc/rocks-treesitter.nvim.txt
+++ b/doc/rocks-treesitter.nvim.txt
@@ -79,6 +79,7 @@ configure this plugin.
     disable = [
       "lhaskell"
     ]
+    config_path = "rocks-treesitter.toml"
     
     [treesitter.parser_map]
     # You can add custom filetype to parser mappings.
@@ -104,6 +105,7 @@ Or, you add a lua table to your `vim.g.rocks_nvim` setting:
             parser_map = { },
             ---@type string[] | fun(lang: string, bufnr: integer):boolean
             disable = { }, -- filetypes or a function
+            config_path = "rocks-treesitter.toml",
         },
     }
 <

--- a/lua/rocks_treesitter/config.lua
+++ b/lua/rocks_treesitter/config.lua
@@ -11,6 +11,8 @@ local config = {
     disable = {},
     ---@type table<string, string>
     parser_map = require("rocks_treesitter.ft_parser_map"),
+    ---@type string?
+    config_path = nil,
 }
 
 local api = require("rocks.api")
@@ -32,6 +34,11 @@ local api = require("rocks.api")
 --- File types to disable highlighting for (lua + toml config)
 --- or a function to conditionally disable highlighting (lua only)
 ---@field disable? string[] | fun(lang: string, bufnr: integer):boolean
+---
+--- Specify a config path, relative to the base rocks config file, to
+--- install treesitter rocks (ex. "rocks-treesitter.toml"). If not set, they will be added
+--- to the base config file
+--- @field config_path? string
 
 local toml_config = api.get_rocks_toml()["treesitter"]
 ---@type RocksTreesitterOpts
@@ -75,5 +82,6 @@ config.disable = type(opts.disable) == "function" and opts.disable
 ---@diagnostic disable-next-line: assign-type-mismatch
 config.auto_install = vim.F.if_nil(opts.auto_install, config.auto_install)
 config.parser_map = vim.tbl_extend("force", config.parser_map, opts.parser_map or {})
+config.config_path = vim.F.if_nil(opts.config_path)
 
 return config

--- a/lua/rocks_treesitter/highlight.lua
+++ b/lua/rocks_treesitter/highlight.lua
@@ -80,7 +80,10 @@ local function install_latest_version(rocks)
             end
         )
     end
-    api.install(rocks[1].name, tostring(latest_version or "dev"), try_start_highlight)
+    api.install(rocks[1].name, tostring(latest_version or "dev"), {
+        callback = try_start_highlight,
+        config_path = config.config_path,
+    })
 end
 
 ---@param rocks Rock[]

--- a/rocks-treesitter.nvim-scm-1.rockspec
+++ b/rocks-treesitter.nvim-scm-1.rockspec
@@ -5,7 +5,7 @@ version = _MODREV .. _SPECREV
 
 dependencies = {
     "lua >= 5.1",
-    "rocks.nvim >= 1.19.0",
+    "rocks.nvim >= 2.42.0",
 }
 
 source = {


### PR DESCRIPTION
Dependent on this PR: https://github.com/nvim-neorocks/rocks.nvim/pull/577

This PR adds support for specifying a config import path to automatically install treesitter rocks into instead of the base config file.