### PR TITLE
feat: add filetype .pacscript to parser map

### DIFF
--- a/lua/rocks_treesitter/ft_parser_map.lua
+++ b/lua/rocks_treesitter/ft_parser_map.lua
@@ -8,6 +8,7 @@
 
 return {
     PKGBUILD = "bash",
+    pacscript = "bash",
     ["html.handlebars"] = "glimmer",
     ["typescript.tsx"] = "tsx",
     apkbuild = "bash",


### PR DESCRIPTION
This commit adds support for pacscripts which is the filetype used by pacstall for its packages.

More info: @pacstall https://github.com/pacstall/pacstall

Seeing PKGBUILD was already in the default, so I thought of adding this as it has came out to be sorta PKGBUILD but for Debian based systems.